### PR TITLE
Allowing to use embedded-hal = "0.2" 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,13 +16,14 @@ version = "3.0.0-alpha.1"
 #
 
 [features]
-default = ["netlink"]
+default = ["netlink", "hal-one"]
 netlink = ["neli"]
 vcan_tests = ["netlink"]
 utils = ["clap", "anyhow"]
+hal-one = ["embedded-hal-one"]
 
 [dependencies]
-embedded-hal = "1.0.0-alpha.8"
+embedded-hal = "0.2"
 nb = "1"
 byte_conv = "0.1.1"
 hex = "0.4"
@@ -32,6 +33,11 @@ nix = "0.23"
 clap = { version = "2.33", optional = true }
 anyhow = { version = "1.0", optional = true }
 neli = { version = "0.6", optional = true }
+
+[dependencies.embedded-hal-one]
+version = "1.0.0-alpha.8"
+package = "embedded-hal"
+optional = true
 
 [dev-dependencies]
 anyhow = "1.0"

--- a/examples/blocking.rs
+++ b/examples/blocking.rs
@@ -8,7 +8,7 @@
 use anyhow::Context;
 use clap::Parser;
 
-use embedded_hal::can::{blocking::Can, Frame, Id, StandardId};
+use embedded_hal_one::can::{blocking::Can, Frame, Id, StandardId};
 use socketcan_hal::{CanFrame, CanSocket};
 
 #[derive(Parser)]

--- a/examples/blocking.rs
+++ b/examples/blocking.rs
@@ -8,9 +8,8 @@
 use anyhow::Context;
 use clap::Parser;
 
-use socketcan_hal::{CanSocket, CanFrame};
 use embedded_hal::can::{blocking::Can, Frame, Id, StandardId};
-
+use socketcan_hal::{CanFrame, CanSocket};
 
 #[derive(Parser)]
 #[clap(author, version, about, long_about = None)]
@@ -20,9 +19,7 @@ struct Args {
     interface: String,
 }
 
-
 fn main() -> anyhow::Result<()> {
-
     let args = Args::parse();
     let can_interface = args.interface;
 
@@ -35,19 +32,22 @@ fn main() -> anyhow::Result<()> {
         println!("{}", frame_to_string(&frame));
     }
 
-    let write_frame = CanFrame::new(
-        StandardId::new(0x1f1).unwrap(),
-        &[1, 2, 3, 4]
-    ).expect("Failed to create CAN frame");
+    let write_frame = CanFrame::new(StandardId::new(0x1f1).unwrap(), &[1, 2, 3, 4])
+        .expect("Failed to create CAN frame");
 
-    socket.transmit(&write_frame).expect("Failed to transmit frame");
+    socket
+        .transmit(&write_frame)
+        .expect("Failed to transmit frame");
 
     Ok(())
 }
 
 fn frame_to_string<F: Frame>(f: &F) -> String {
     let id = get_raw_id(&f.id());
-    let data_string = f.data().iter().fold(String::from(""), |a, b| format!("{} {:02x}", a, b));
+    let data_string = f
+        .data()
+        .iter()
+        .fold(String::from(""), |a, b| format!("{} {:02x}", a, b));
 
     format!("{:08X}  [{}] {}", id, f.dlc(), data_string)
 }

--- a/examples/echo.rs
+++ b/examples/echo.rs
@@ -8,12 +8,11 @@
 use anyhow::Context;
 use clap::Parser;
 
-use socketcan_hal::{CanSocket, CanFrame};
 use embedded_hal::can::{blocking::Can, Frame, Id, StandardId};
+use socketcan_hal::{CanFrame, CanSocket};
 
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
-
 
 #[derive(Parser)]
 #[clap(author, version, about, long_about = None)]
@@ -23,38 +22,37 @@ struct Args {
     interface: String,
 }
 
-
 fn main() -> anyhow::Result<()> {
-
     let args = Args::parse();
     let can_interface = args.interface;
 
     let mut socket = CanSocket::open(&can_interface)
         .with_context(|| format!("Failed to open socket on interface {}", can_interface))?;
-    socket.set_nonblocking(true).with_context(|| format!("Failed to make socket non-blocking"))?;
+    socket
+        .set_nonblocking(true)
+        .with_context(|| "Failed to make socket non-blocking".to_string())?;
 
     let shutdown = AtomicBool::new(false);
     let shutdown = Arc::new(shutdown);
     let signal_shutdown = shutdown.clone();
 
-    ctrlc::set_handler(move ||{
+    ctrlc::set_handler(move || {
         signal_shutdown.store(true, Ordering::Relaxed);
     })
     .expect("Failed to set signal handler");
 
     while !shutdown.load(Ordering::Relaxed) {
-        match socket.receive() {
-            Ok(frame) => {
-                println!("{}", frame_to_string(&frame));
+        if let Ok(frame) = socket.receive() {
+            println!("{}", frame_to_string(&frame));
 
-                let new_id = get_raw_id(&frame.id()) + 0x01;
-                let new_id = StandardId::new(new_id as u16).expect("Failed to create ID");
+            let new_id = get_raw_id(&frame.id()) + 0x01;
+            let new_id = StandardId::new(new_id as u16).expect("Failed to create ID");
 
-                if let Some(echo_frame) = CanFrame::new(new_id, frame.data()) {
-                    socket.transmit(&echo_frame).expect("Failed to echo recieved frame");
-                }
-            },
-            Err(_) => {},
+            if let Some(echo_frame) = CanFrame::new(new_id, frame.data()) {
+                socket
+                    .transmit(&echo_frame)
+                    .expect("Failed to echo recieved frame");
+            }
         }
     }
 
@@ -64,7 +62,10 @@ fn main() -> anyhow::Result<()> {
 fn frame_to_string<F: Frame>(f: &F) -> String {
     let id = get_raw_id(&f.id());
 
-    let data_string = f.data().iter().fold(String::from(""), |a, b| format!("{} {:02x}", a, b));
+    let data_string = f
+        .data()
+        .iter()
+        .fold(String::from(""), |a, b| format!("{} {:02x}", a, b));
 
     format!("{:08X}  [{}] {}", id, f.dlc(), data_string)
 }

--- a/examples/echo.rs
+++ b/examples/echo.rs
@@ -8,7 +8,7 @@
 use anyhow::Context;
 use clap::Parser;
 
-use embedded_hal::can::{blocking::Can, Frame, Id, StandardId};
+use embedded_hal_one::can::{blocking::Can, Frame, Id, StandardId};
 use socketcan_hal::{CanFrame, CanSocket};
 
 use std::sync::atomic::{AtomicBool, Ordering};

--- a/examples/nonblocking.rs
+++ b/examples/nonblocking.rs
@@ -8,7 +8,7 @@
 use anyhow::Context;
 use clap::Parser;
 
-use embedded_hal::can::{nb::Can, Frame, Id, StandardId};
+use embedded_hal_one::can::{nb::Can, Frame, Id, StandardId};
 use nb::block;
 use socketcan_hal::{CanFrame, CanSocket};
 

--- a/examples/nonblocking.rs
+++ b/examples/nonblocking.rs
@@ -8,10 +8,9 @@
 use anyhow::Context;
 use clap::Parser;
 
-use socketcan_hal::{CanSocket, CanFrame};
 use embedded_hal::can::{nb::Can, Frame, Id, StandardId};
 use nb::block;
-
+use socketcan_hal::{CanFrame, CanSocket};
 
 #[derive(Parser)]
 #[clap(author, version, about, long_about = None)]
@@ -21,15 +20,15 @@ struct Args {
     interface: String,
 }
 
-
 fn main() -> anyhow::Result<()> {
-
     let args = Args::parse();
     let can_interface = args.interface;
 
     let mut socket = CanSocket::open(&can_interface)
         .with_context(|| format!("Failed to open socket on interface {}", can_interface))?;
-    socket.set_nonblocking(true).with_context(|| format!("Failed to make socket non-blocking"))?;
+    socket
+        .set_nonblocking(true)
+        .with_context(|| "Failed to make socket non-blocking".to_string())?;
 
     let frame = block!(socket.receive());
 
@@ -37,10 +36,8 @@ fn main() -> anyhow::Result<()> {
         println!("{}", frame_to_string(&frame));
     }
 
-    let write_frame = CanFrame::new(
-        StandardId::new(0x1f1).unwrap(),
-        &[1, 2, 3, 4]
-    ).expect("Failed to create CAN frame");
+    let write_frame = CanFrame::new(StandardId::new(0x1f1).unwrap(), &[1, 2, 3, 4])
+        .expect("Failed to create CAN frame");
 
     if let Err(e) = block!(socket.transmit(&write_frame)) {
         println!("{}", e);
@@ -51,7 +48,10 @@ fn main() -> anyhow::Result<()> {
 
 fn frame_to_string<F: Frame>(f: &F) -> String {
     let id = get_raw_id(&f.id());
-    let data_string = f.data().iter().fold(String::from(""), |a, b| format!("{} {:02x}", a, b));
+    let data_string = f
+        .data()
+        .iter()
+        .fold(String::from(""), |a, b| format!("{} {:02x}", a, b));
 
     format!("{:08X}  [{}] {}", id, f.dlc(), data_string)
 }

--- a/src/bin/can.rs
+++ b/src/bin/can.rs
@@ -4,12 +4,7 @@
 //! command line, similar to 'can-utils'.
 
 use anyhow::{anyhow, Result};
-use clap::{
-    App,
-    Arg,
-    ArgMatches,
-    SubCommand,
-};
+use clap::{App, Arg, ArgMatches, SubCommand};
 use socketcan::CanInterface;
 use std::process;
 
@@ -26,16 +21,10 @@ fn iface_cmd(iface_name: &str, opts: &ArgMatches) -> Result<()> {
     let iface = CanInterface::open(iface_name)?;
 
     match opts.subcommand_name() {
-        Some("up") => {
-            iface.bring_up()
-        },
-        Some("down") => {
-            iface.bring_down()
-        },
-        Some("bitrate") => {
-            return Err(anyhow!("Unimplemented"))
-        },
-        _ => return Err(anyhow!("Unknown 'iface' subcommand"))
+        Some("up") => iface.bring_up(),
+        Some("down") => iface.bring_down(),
+        Some("bitrate") => return Err(anyhow!("Unimplemented")),
+        _ => return Err(anyhow!("Unknown 'iface' subcommand")),
     }?;
     Ok(())
 }
@@ -55,27 +44,21 @@ fn main() {
         .version(VERSION)
         .about("Command line tool to interact with the CAN bus on Linux")
         .help_short("?")
-        .arg(Arg::with_name("iface")
-            .help("The CAN interface to use, like 'can0', 'vcan0', etc")
-            .required(true)
-            .index(1))
+        .arg(
+            Arg::with_name("iface")
+                .help("The CAN interface to use, like 'can0', 'vcan0', etc")
+                .required(true)
+                .index(1),
+        )
         .subcommand(
             SubCommand::with_name("iface")
                 .help_short("?")
                 .about("Get/set parameters on the CAN interface")
+                .subcommand(SubCommand::with_name("up").about("Bring the interface up"))
+                .subcommand(SubCommand::with_name("down").about("Bring the interface down"))
                 .subcommand(
-                    SubCommand::with_name("up")
-                        .about("Bring the interface up")
-                )
-                .subcommand(
-                    SubCommand::with_name("down")
-                        .about("Bring the interface down")
-                )
-                .subcommand(
-                    SubCommand::with_name("bitrate")
-                        .about("Set the bit rate on the interface.")
-                )
-
+                    SubCommand::with_name("bitrate").about("Set the bit rate on the interface."),
+                ),
         )
         .get_matches();
 
@@ -83,8 +66,7 @@ fn main() {
 
     let res = if let Some(sub_opts) = opts.subcommand_matches("iface") {
         iface_cmd(&iface_name, &sub_opts)
-    }
-    else {
+    } else {
         Err(anyhow!("Need to specify a subcommand (-? for help)."))
     };
 
@@ -93,4 +75,3 @@ fn main() {
         process::exit(1);
     }
 }
-

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -21,10 +21,10 @@ pub const CAN_RAW_RECV_OWN_MSGS: c_int = 4;
 pub const CAN_RAW_JOIN_FILTERS: c_int = 6;
 
 // get timestamp in a struct timeval (us accuracy)
-// const SIOCGSTAMP: c_int = 0x8906;
+// const SIOCGSTAMP: u16 = 0x8906;
 
 // get timestamp in a struct timespec (ns accuracy)
-pub const SIOCGSTAMPNS: c_int = 0x8907;
+pub const SIOCGSTAMPNS: u16 = 0x8907;
 
 /// if set, indicate 29 bit extended format
 pub const EFF_FLAG: u32 = 0x80000000;

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -4,9 +4,7 @@
 // @author Natesh Narain <nnaraindev@gmail.com>
 // @date Jul 06 2022
 //
-use std::{
-    os::raw::c_int,
-};
+use std::os::raw::c_int;
 
 // constants stolen from C headers
 pub const AF_CAN: c_int = 29;
@@ -21,7 +19,6 @@ pub const CAN_RAW_RECV_OWN_MSGS: c_int = 4;
 // unused:
 // const CAN_RAW_FD_FRAMES: c_int = 5;
 pub const CAN_RAW_JOIN_FILTERS: c_int = 6;
-
 
 // get timestamp in a struct timeval (us accuracy)
 // const SIOCGSTAMP: c_int = 0x8906;
@@ -46,7 +43,6 @@ pub const EFF_MASK: u32 = 0x1fffffff;
 
 /// valid bits in error frame
 pub const ERR_MASK: u32 = 0x1fffffff;
-
 
 /// an error mask that will cause SocketCAN to report all errors
 pub const ERR_MASK_ALL: u32 = ERR_MASK;

--- a/src/dump.rs
+++ b/src/dump.rs
@@ -180,8 +180,8 @@ impl<'a, R: io::Read> Iterator for CanDumpRecords<'a, io::BufReader<R>> {
 #[cfg(test)]
 mod test {
     use super::Reader;
+    use crate::embedded_hal::can::Frame;
     use crate::util::hal_id_to_raw;
-    use embedded_hal::can::Frame;
 
     #[test]
     fn test_simple_example() {

--- a/src/err.rs
+++ b/src/err.rs
@@ -2,7 +2,7 @@
 //                  /include/uapi/linux/can/error.h
 
 use super::CanFrame;
-use embedded_hal::can::Frame;
+use crate::embedded_hal::can::Frame;
 use std::{convert::TryFrom, error, fmt, io};
 
 #[inline]
@@ -119,18 +119,18 @@ impl fmt::Display for CanError {
     }
 }
 
-impl embedded_hal::can::Error for CanError {
-    fn kind(&self) -> embedded_hal::can::ErrorKind {
+impl crate::embedded_hal::can::Error for CanError {
+    fn kind(&self) -> crate::embedded_hal::can::ErrorKind {
         match *self {
             CanError::ControllerProblem(cp) => match cp {
                 ControllerProblem::ReceiveBufferOverflow
                 | ControllerProblem::TransmitBufferOverflow => {
-                    embedded_hal::can::ErrorKind::Overrun
+                    crate::embedded_hal::can::ErrorKind::Overrun
                 }
-                _ => embedded_hal::can::ErrorKind::Other,
+                _ => crate::embedded_hal::can::ErrorKind::Other,
             },
-            CanError::NoAck => embedded_hal::can::ErrorKind::Acknowledge,
-            _ => embedded_hal::can::ErrorKind::Other,
+            CanError::NoAck => crate::embedded_hal::can::ErrorKind::Acknowledge,
+            _ => crate::embedded_hal::can::ErrorKind::Other,
         }
     }
 }

--- a/src/err.rs
+++ b/src/err.rs
@@ -3,23 +3,17 @@
 
 use super::CanFrame;
 use embedded_hal::can::Frame;
-use std::{
-    convert::TryFrom,
-    error,
-    fmt,
-    io,
-};
-
+use std::{convert::TryFrom, error, fmt, io};
 
 #[inline]
 /// Helper function to retrieve a specific byte of frame data or returning an
 /// `Err(..)` otherwise.
 fn get_data(frame: &CanFrame, idx: u8) -> Result<u8, CanErrorDecodingFailure> {
-    Ok(*(frame.data()
+    Ok(*(frame
+        .data()
         .get(idx as usize)
         .ok_or(CanErrorDecodingFailure::NotEnoughData(idx)))?)
 }
-
 
 /// Error decoding a CanError from a CanFrame.
 #[derive(Copy, Clone, Debug)]
@@ -65,7 +59,6 @@ impl fmt::Display for CanErrorDecodingFailure {
         write!(f, "{}", msg)
     }
 }
-
 
 #[derive(Copy, Clone, Debug)]
 pub enum CanError {
@@ -129,11 +122,12 @@ impl fmt::Display for CanError {
 impl embedded_hal::can::Error for CanError {
     fn kind(&self) -> embedded_hal::can::ErrorKind {
         match *self {
-            CanError::ControllerProblem(cp) => {
-                match cp {
-                    ControllerProblem::ReceiveBufferOverflow | ControllerProblem::TransmitBufferOverflow => embedded_hal::can::ErrorKind::Overrun,
-                    ControllerProblem::Unspecified | _ => embedded_hal::can::ErrorKind::Other,
+            CanError::ControllerProblem(cp) => match cp {
+                ControllerProblem::ReceiveBufferOverflow
+                | ControllerProblem::TransmitBufferOverflow => {
+                    embedded_hal::can::ErrorKind::Overrun
                 }
+                _ => embedded_hal::can::ErrorKind::Other,
             },
             CanError::NoAck => embedded_hal::can::ErrorKind::Acknowledge,
             _ => embedded_hal::can::ErrorKind::Other,
@@ -437,16 +431,14 @@ impl CanError {
         match frame.err() {
             0x00000001 => Ok(CanError::TransmitTimeout),
             0x00000002 => Ok(CanError::LostArbitration(get_data(frame, 0)?)),
-            0x00000004 => {
-                Ok(CanError::ControllerProblem(ControllerProblem::try_from(get_data(frame, 1)?)?))
-            }
+            0x00000004 => Ok(CanError::ControllerProblem(ControllerProblem::try_from(
+                get_data(frame, 1)?,
+            )?)),
 
-            0x00000008 => {
-                Ok(CanError::ProtocolViolation {
-                    vtype: ViolationType::try_from(get_data(frame, 2)?)?,
-                    location: Location::try_from(get_data(frame, 3)?)?,
-                })
-            }
+            0x00000008 => Ok(CanError::ProtocolViolation {
+                vtype: ViolationType::try_from(get_data(frame, 2)?)?,
+                location: Location::try_from(get_data(frame, 3)?)?,
+            }),
 
             0x00000010 => Ok(CanError::TransceiverError),
             0x00000020 => Ok(CanError::NoAck),
@@ -529,5 +521,3 @@ impl From<io::Error> for CanSocketOpenError {
         CanSocketOpenError::IOError(e)
     }
 }
-
-

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -1,12 +1,11 @@
-use crate::err::{ConstructionError, CanError, CanErrorDecodingFailure};
-use embedded_hal::can::{Frame, Id, StandardId, ExtendedId};
 use crate::constants::*;
+use crate::err::{CanError, CanErrorDecodingFailure, ConstructionError};
 use crate::util::hal_id_to_raw;
+use embedded_hal::can::{ExtendedId, Frame, Id, StandardId};
 
 use std::fmt;
 
 use itertools::Itertools;
-
 
 /// CanFrame
 ///
@@ -51,7 +50,6 @@ impl CanFrame {
             _id |= EFF_FLAG;
         }
 
-
         if rtr {
             _id |= RTR_FLAG;
         }
@@ -68,13 +66,13 @@ impl CanFrame {
         }
 
         Ok(CanFrame {
-               _id,
-               _data_len: data.len() as u8,
-               _pad: 0,
-               _res0: 0,
-               _res1: 0,
-               _data: full_data,
-           })
+            _id,
+            _data_len: data.len() as u8,
+            _pad: 0,
+            _res0: 0,
+            _res1: 0,
+            _data: full_data,
+        })
     }
 
     /// Return the error message
@@ -99,7 +97,6 @@ impl CanFrame {
     pub fn error(&self) -> Result<CanError, CanErrorDecodingFailure> {
         CanError::from_frame(self)
     }
-
 }
 
 impl Frame for CanFrame {
@@ -119,13 +116,9 @@ impl Frame for CanFrame {
     /// Return the actual CAN ID (without EFF/RTR/ERR flags)
     fn id(&self) -> Id {
         if self.is_extended() {
-            Id::Extended(
-                ExtendedId::new(self._id & EFF_MASK).unwrap()
-            )
+            Id::Extended(ExtendedId::new(self._id & EFF_MASK).unwrap())
         } else {
-            Id::Standard(
-                StandardId::new((self._id & SFF_MASK) as u16).unwrap()
-            )
+            Id::Standard(StandardId::new((self._id & SFF_MASK) as u16).unwrap())
         }
     }
 
@@ -138,7 +131,7 @@ impl Frame for CanFrame {
     fn is_remote_frame(&self) -> bool {
         self._id & RTR_FLAG != 0
     }
-    
+
     /// Data length
     fn dlc(&self) -> usize {
         self._data_len as usize
@@ -160,4 +153,3 @@ impl fmt::UpperHex for CanFrame {
         write!(f, "{}", parts.join(sep))
     }
 }
-

--- a/src/frame/id.rs
+++ b/src/frame/id.rs
@@ -1,0 +1,23 @@
+use super::{ConstructionError, ExtendedId, Id, StandardId, SFF_MASK};
+
+/// This trait allows to use the same structure for the CAN Identifier as in the embedded-hal crate.
+pub trait IntoCanId {
+    fn to_can_id(&self) -> Result<Id, ConstructionError>;
+}
+
+impl IntoCanId for u32 {
+    fn to_can_id(&self) -> Result<Id, ConstructionError> {
+        if *self > SFF_MASK {
+            ExtendedId::new(*self).map(Id::Extended)
+        } else {
+            StandardId::new(*self as u16).map(Id::Standard)
+        }
+        .ok_or(ConstructionError::IDTooLarge)
+    }
+}
+
+impl IntoCanId for Id {
+    fn to_can_id(&self) -> Result<Id, ConstructionError> {
+        Ok(*self)
+    }
+}

--- a/src/frame/mod.rs
+++ b/src/frame/mod.rs
@@ -1,9 +1,9 @@
 mod id;
 
 use crate::constants::*;
+use crate::embedded_hal::can::{ExtendedId, Frame, Id, StandardId};
 use crate::err::{CanError, CanErrorDecodingFailure, ConstructionError};
 use crate::util::hal_id_to_raw;
-use embedded_hal::can::{ExtendedId, Frame, Id, StandardId};
 pub use id::IntoCanId;
 use itertools::Itertools;
 use std::fmt;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,8 +82,15 @@ mod nl;
 #[cfg(feature = "netlink")]
 pub use nl::CanInterface;
 
+#[cfg(feature = "hal-one")]
+use embedded_hal_one as embedded_hal;
+
+#[cfg(not(feature = "hal-one"))]
+use embedded_hal;
+
 use std::io::ErrorKind;
 
+#[cfg(feature = "hal-one")]
 impl embedded_hal::can::blocking::Can for CanSocket {
     type Frame = CanFrame;
     type Error = CanError;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,7 +70,7 @@ pub use frame::CanFrame;
 pub mod constants;
 
 mod socket;
-pub use socket::{CanSocket, CanFilter, ShouldRetry};
+pub use socket::{CanFilter, CanSocket, ShouldRetry};
 
 pub mod dump;
 
@@ -84,7 +84,6 @@ pub use nl::CanInterface;
 
 use std::io::ErrorKind;
 
-
 impl embedded_hal::can::blocking::Can for CanSocket {
     type Frame = CanFrame;
     type Error = CanError;
@@ -97,11 +96,11 @@ impl embedded_hal::can::blocking::Can for CanSocket {
                 } else {
                     Err(frame.error().unwrap_or(CanError::Unknown(0)))
                 }
-            },
+            }
             Err(e) => {
                 let code = e.raw_os_error().unwrap_or(0);
                 Err(CanError::Unknown(code as u32))
-            },
+            }
         }
     }
 
@@ -111,7 +110,7 @@ impl embedded_hal::can::blocking::Can for CanSocket {
             Err(e) => {
                 let code = e.raw_os_error().unwrap_or(0);
                 Err(CanError::Unknown(code as u32))
-            },
+            }
         }
     }
 }
@@ -129,7 +128,7 @@ impl embedded_hal::can::nb::Can for CanSocket {
                     let can_error = frame.error().unwrap_or(CanError::Unknown(0));
                     Err(nb::Error::Other(can_error))
                 }
-            },
+            }
             Err(e) => {
                 let e = match e.kind() {
                     ErrorKind::WouldBlock => nb::Error::WouldBlock,
@@ -144,7 +143,7 @@ impl embedded_hal::can::nb::Can for CanSocket {
     }
 
     fn transmit(&mut self, frame: &Self::Frame) -> nb::Result<Option<Self::Frame>, Self::Error> {
-        match self.write_frame(&frame) {
+        match self.write_frame(frame) {
             Ok(_) => Ok(None),
             Err(e) => {
                 match e.kind() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,7 +65,7 @@ mod err;
 pub use err::{CanError, CanErrorDecodingFailure, CanSocketOpenError, ConstructionError};
 
 mod frame;
-pub use frame::CanFrame;
+pub use frame::{CanFrame, IntoCanId};
 
 pub mod constants;
 

--- a/src/nl.rs
+++ b/src/nl.rs
@@ -12,21 +12,21 @@
 
 use neli::{
     consts::{
-        nl::{NlmF, NlmFFlags, NlType},
+        nl::{NlType, NlmF, NlmFFlags},
         rtnl::{Arphrd, RtAddrFamily, Rtm},
         socket::NlFamily,
     },
     err::NlError,
-    nl::{Nlmsghdr, NlPayload},
+    nl::{NlPayload, Nlmsghdr},
     rtnl::Ifinfomsg,
-    ToBytes,
-    types::RtBuffer,
     socket::NlSocketHandle,
+    types::RtBuffer,
+    ToBytes,
 };
-use nix::{self, unistd, net::if_::if_nametoindex};
+use nix::{self, net::if_::if_nametoindex, unistd};
 use std::{
-    os::raw::{c_int, c_uint},
     fmt::Debug,
+    os::raw::{c_int, c_uint},
 };
 
 /// A result for Netlink errors.
@@ -54,7 +54,9 @@ impl CanInterface {
     /// Creates a new `CanInterface` instance. No actual "opening" is necessary
     /// or performed when calling this function.
     pub fn open_iface(if_index: u32) -> Self {
-        Self { if_index: if_index as c_uint }
+        Self {
+            if_index: if_index as c_uint,
+        }
     }
 
     /// Sends an info message
@@ -73,7 +75,6 @@ impl CanInterface {
         // send the message
         Self::send_and_read_ack(&mut nl, hdr)
     }
-
 
     /// Sends a netlink message down a netlink socket, and checks if an ACK was
     /// properly received.
@@ -107,7 +108,7 @@ impl CanInterface {
             RtAddrFamily::Unspecified,
             Arphrd::Netrom,
             self.if_index as c_int,
-            RtBuffer::new()
+            RtBuffer::new(),
         );
         Self::send_info_msg(info)
     }
@@ -120,7 +121,7 @@ impl CanInterface {
             RtAddrFamily::Unspecified,
             Arphrd::Netrom,
             self.if_index as c_int,
-            RtBuffer::new()
+            RtBuffer::new(),
         );
         Self::send_info_msg(info)
     }

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -1,22 +1,20 @@
-
-use crate::frame::CanFrame;
-use crate::err::{CanSocketOpenError, ConstructionError};
-use crate::util::{set_socket_option, set_socket_option_mult, system_time_from_timespec};
 use crate::constants::*;
+use crate::err::{CanSocketOpenError, ConstructionError};
+use crate::frame::CanFrame;
+use crate::util::{set_socket_option, set_socket_option_mult, system_time_from_timespec};
 
-
-use libc::{socket, SOCK_RAW, close, bind, sockaddr, read,
-    write, SOL_SOCKET, SO_RCVTIMEO, timespec, timeval, EINPROGRESS, SO_SNDTIMEO, time_t,
-    suseconds_t, fcntl, F_GETFL, F_SETFL, O_NONBLOCK};
-use nix::net::if_::if_nametoindex;
-use std::{
-    os::raw::{c_int, c_short, c_void, c_uint, c_ulong},
-    fmt,
-    io,
-    time,
-    mem::size_of,
+use libc::{
+    bind, close, fcntl, read, sockaddr, socket, suseconds_t, time_t, timespec, timeval, write,
+    EINPROGRESS, F_GETFL, F_SETFL, O_NONBLOCK, SOCK_RAW, SOL_SOCKET, SO_RCVTIMEO, SO_SNDTIMEO,
 };
+use nix::net::if_::if_nametoindex;
 use std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
+use std::{
+    fmt, io,
+    mem::size_of,
+    os::raw::{c_int, c_short, c_uint, c_ulong, c_void},
+    time,
+};
 
 /// Check an error return value for timeouts.
 ///
@@ -60,7 +58,6 @@ impl<E: fmt::Debug> ShouldRetry for io::Result<E> {
         }
     }
 }
-
 
 fn c_timeval_new(t: time::Duration) -> timeval {
     timeval {
@@ -122,9 +119,11 @@ impl CanSocket {
         let bind_rv;
         unsafe {
             let sockaddr_ptr = &addr as *const CanAddr;
-            bind_rv = bind(sock_fd,
-                           sockaddr_ptr as *const sockaddr,
-                           size_of::<CanAddr>() as u32);
+            bind_rv = bind(
+                sock_fd,
+                sockaddr_ptr as *const sockaddr,
+                size_of::<CanAddr>() as u32,
+            );
         }
 
         // FIXME: on fail, close socket (do not leak socketfds)
@@ -209,10 +208,12 @@ impl CanSocket {
     pub fn read_frame_with_timestamp(&mut self) -> io::Result<(CanFrame, time::SystemTime)> {
         let frame = self.read_frame()?;
 
-        let mut ts = timespec { tv_sec: 0, tv_nsec: 0 };
-        let rval = unsafe {
-            libc::ioctl(self.fd, SIOCGSTAMPNS as c_ulong, &mut ts as *mut timespec)
+        let mut ts = timespec {
+            tv_sec: 0,
+            tv_nsec: 0,
         };
+        let rval =
+            unsafe { libc::ioctl(self.fd, SIOCGSTAMPNS as c_ulong, &mut ts as *mut timespec) };
 
         if rval == -1 {
             return Err(io::Error::last_os_error());
@@ -319,7 +320,7 @@ impl AsRawFd for CanSocket {
 
 impl FromRawFd for CanSocket {
     unsafe fn from_raw_fd(fd: RawFd) -> CanSocket {
-        CanSocket { fd, }
+        CanSocket { fd }
     }
 }
 
@@ -334,7 +335,6 @@ impl Drop for CanSocket {
         self.close().ok(); // ignore result
     }
 }
-
 
 /// CanFilter
 ///
@@ -351,8 +351,8 @@ impl CanFilter {
     /// Construct a new CAN filter.
     pub fn new(id: u32, mask: u32) -> Result<CanFilter, ConstructionError> {
         Ok(CanFilter {
-               _id: id,
-               _mask: mask,
-           })
+            _id: id,
+            _mask: mask,
+        })
     }
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,4 +1,4 @@
-use embedded_hal::can::Id;
+use crate::embedded_hal::can::Id;
 use libc::{c_int, c_void, setsockopt, socklen_t, timespec};
 use std::mem::size_of;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,8 +1,8 @@
+use embedded_hal::can::Id;
 use libc::{c_int, c_void, setsockopt, socklen_t, timespec};
-use std::{io, ptr};
 use std::mem::size_of;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
-use embedded_hal::can::Id;
+use std::{io, ptr};
 
 /// `setsockopt` wrapper
 ///
@@ -27,11 +27,13 @@ pub fn set_socket_option<T>(fd: c_int, level: c_int, name: c_int, val: &T) -> io
     let rv = unsafe {
         let val_ptr: *const T = val as *const T;
 
-        setsockopt(fd,
-                   level,
-                   name,
-                   val_ptr as *const c_void,
-                   size_of::<T>() as socklen_t)
+        setsockopt(
+            fd,
+            level,
+            name,
+            val_ptr as *const c_void,
+            size_of::<T>() as socklen_t,
+        )
     };
 
     if rv != 0 {
@@ -41,12 +43,12 @@ pub fn set_socket_option<T>(fd: c_int, level: c_int, name: c_int, val: &T) -> io
     Ok(())
 }
 
-pub fn set_socket_option_mult<T>(fd: c_int,
-                                 level: c_int,
-                                 name: c_int,
-                                 values: &[T])
-                                 -> io::Result<()> {
-
+pub fn set_socket_option_mult<T>(
+    fd: c_int,
+    level: c_int,
+    name: c_int,
+    values: &[T],
+) -> io::Result<()> {
     let rv = if values.is_empty() {
         // can't pass in a pointer to the first element if a 0-length slice,
         // pass a nullpointer instead
@@ -55,11 +57,13 @@ pub fn set_socket_option_mult<T>(fd: c_int,
         unsafe {
             let val_ptr = &values[0] as *const T;
 
-            setsockopt(fd,
-                       level,
-                       name,
-                       val_ptr as *const c_void,
-                       (size_of::<T>() * values.len()) as socklen_t)
+            setsockopt(
+                fd,
+                level,
+                name,
+                val_ptr as *const c_void,
+                (size_of::<T>() * values.len()) as socklen_t,
+            )
         }
     };
 

--- a/tests/cansocket.rs
+++ b/tests/cansocket.rs
@@ -1,4 +1,4 @@
-use socketcan_hal::{CanSocket, CanFrame, ShouldRetry, constants::*};
+use socketcan_hal::{constants::*, CanFrame, CanSocket, ShouldRetry};
 use std::time;
 
 #[test]


### PR DESCRIPTION
Not all the other crates are compatible with
`embedded-hal v1.0.0-alpha.8`

For example: https://github.com/stm32-rs/stm32f4xx-hal
uses `embedded-hal v1.0.0-alpha.7`
but don't compile when using `embedded-hal v1.0.0-alpha.8`.
Note: `stm32f4xx-hal` also uses the two versions of `embedded-hal`